### PR TITLE
read in bulk

### DIFF
--- a/web/2-read/cassandra-ext.php
+++ b/web/2-read/cassandra-ext.php
@@ -4,13 +4,17 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 $cluster = Cassandra::cluster()->build();
 $session   = $cluster->connect('ext');
+$statement = new Cassandra\SimpleStatement("SELECT * FROM user WHERE id = ?");
+$options   = new Cassandra\ExecutionOptions();
+$futures   = array();
+
+for ($index = 0; $index < 100; $index++) {
+    $options->arguments = array(rand(0, 1000000));
+    $futures[]= $session->executeAsync($statement, $options);
+}
 
 $res = array();
-for ($index = 0; $index < 100; $index++) {
-    $id = rand(0, 1000000);
-
-    $statement = new Cassandra\SimpleStatement("SELECT * FROM user WHERE id = $id");
-    $future    = $session->executeAsync($statement);
+foreach ($futures as $future) {
     /** @var \Cassandra\Rows $result */
     $result    = $future->get();
     if($result->count()){


### PR DESCRIPTION
instead of blocking for each execution, execute all select statements at once and gather results in the end
also don't initialize a new statement, but use execution options with positional arguments instead